### PR TITLE
pbaa2vcf add runName as valid option for sample name info

### DIFF
--- a/vcf/consensusVariants.py
+++ b/vcf/consensusVariants.py
@@ -232,7 +232,7 @@ def parseHiLAAfastaName(fa):
     if fa.endswith('failed_cluster_sequences.fasta'):
         return 'failed'
     else:
-        raise ConsensusVariants_Error(f'Input fasta {fa} not in HiLAA format')
+        raise ConsensusVariants_Error(f'Input fasta {fa} not in pbAA format')
 
 def getKey(*args):
     return hashlib.md5(''.join(map(str,args)).encode()).hexdigest()
@@ -394,11 +394,11 @@ READINFOCOLS = ['readName',
 if __name__ == '__main__':
     import argparse,sys
 
-    parser = argparse.ArgumentParser(prog='consensusVariants.py', description='Write HiLAA consensus variants to table format')
+    parser = argparse.ArgumentParser(prog='consensusVariants.py', description='Write pbAA consensus variants to table format')
     parser.add_argument('reference', metavar='reference', type=str,
                     help='Reference fasta or mmi')
     parser.add_argument('consensusFastas', metavar='consensusFastas', nargs='*', type=str,
-                    help='Fasta file(s) of HiLAA consensus outputs')
+                    help='Fasta file(s) of pbAA consensus outputs')
     parser.add_argument('-r','--runName', dest='runName', type=str, default=None, required=True,
                     help=f'Sequencing run ID')
     parser.add_argument('-p','--prefix', dest='prefix', type=str, default=DEFAULTPREFIX, required=False,

--- a/vcf/pbaa2vcf.py
+++ b/vcf/pbaa2vcf.py
@@ -141,8 +141,12 @@ class VcfCreator:
     def _mergeAlts(self,rows):
         '''merges alt calls for multiple calls at same pos for one sample'''
         r = sorted(rows.ref.values,key=len)[-1]
-        return pd.Series({'ref':r,
-                          'alt':rows[rows.ref!=r].alt.iloc[0] + r[1:]})
+        a = rows[rows.ref!=r].alt.iloc[0]
+        if len(a) == 1: #sub
+            alt = a + r[1:]
+        else: #ins
+            alt = a
+        return pd.Series({'ref':r,'alt':alt})
 
     def new_record(self,loc,data):
         #alts df

--- a/vcf/pbaa2vcf.py
+++ b/vcf/pbaa2vcf.py
@@ -188,7 +188,7 @@ class VcfCreator:
 
             #Genotype
             srec['GT']  = list(alts.reset_index(['CHR','POS'],drop=True)\
-                                   .reindex(calls[calls.index.duplicated(keep='last')].index.get_level_values('uuid'))\
+                                   .reindex(calls[~calls.index.duplicated(keep='first')].index.get_level_values('uuid'))\
                                    .fillna(alleles[0])\
                                    .alt.map(alleles.index))
             srec.phased = not merged 

--- a/vcf/pbaa2vcf.py
+++ b/vcf/pbaa2vcf.py
@@ -241,7 +241,7 @@ if __name__ == '__main__':
                     help='Variants csv from consensusVariants.py')
     parser.add_argument('reference', metavar='reference', type=str,
                     help='Reference fasta (must be indexed)')
-    parser.add_argument('-s','--sampleCol', dest='sampleCol', type=str, choices=['barcode','bioSample'], default='barcode',
+    parser.add_argument('-s','--sampleCol', dest='sampleCol', type=str, choices=['barcode','bioSample','runName'], default='barcode',
                     help=f'Column in allelesCsv to use for grouping samples. Default barcode')
     parser.add_argument('-o','--out', dest='out', type=str, default=None,
                     help=f'Output file. Default stdout')


### PR DESCRIPTION
this allows us to get biosample into the vcf by using the runname option set during the. consensusVariants call